### PR TITLE
Mirror URL and gitee fallback patches for 4.0 releas branch

### DIFF
--- a/chipsets/alientek.xml
+++ b/chipsets/alientek.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/alientek/alientek.xml
+++ b/chipsets/alientek/alientek.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="vendor_alientek" path="vendor/alientek" groups="default,ohos:mini"/>

--- a/chipsets/all.xml
+++ b/chipsets/all.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
   <include name="chipsets/dev_wifi_a/dev_wifi_a.xml" />
   <include name="chipsets/gr5515_sk/gr5515_sk.xml" />

--- a/chipsets/bearpi_hm_micro.xml
+++ b/chipsets/bearpi_hm_micro.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/bearpi_hm_micro/bearpi_hm_micro.xml
+++ b/chipsets/bearpi_hm_micro/bearpi_hm_micro.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_board_bearpi" path="device/board/bearpi" groups="default,ohos:mini,ohos:small"/>

--- a/chipsets/bearpi_hm_nano.xml
+++ b/chipsets/bearpi_hm_nano.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/beken_7235.xml
+++ b/chipsets/beken_7235.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/beken_7235/beken_7235.xml
+++ b/chipsets/beken_7235/beken_7235.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_soc_beken" path="device/soc/beken" groups="default,ohos:mini"/>

--- a/chipsets/cst85_wblink.xml
+++ b/chipsets/cst85_wblink.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/cst85_wblink/cst85_wblink.xml
+++ b/chipsets/cst85_wblink/cst85_wblink.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_soc_chipsea" path="device/soc/chipsea" groups="default,ohos:mini"/>

--- a/chipsets/dayu200.xml
+++ b/chipsets/dayu200.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/dayu200/dayu200.xml
+++ b/chipsets/dayu200/dayu200.xml
@@ -3,7 +3,9 @@
   <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
-  <project name="device_board_hihope" path="device/board/hihope" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:chipset"/>
-  <project name="device_soc_rockchip" path="device/soc/rockchip" groups="default,ohos:standard,ohos:chipset"/>
+  <remote name="gitee" fetch="https://gitee.com/openharmony/" />
+
+  <project name="device_board_hihope" remote="gitee" path="device/board/hihope" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:chipset"/>
+  <project name="device_soc_rockchip" remote="gitee" path="device/soc/rockchip" groups="default,ohos:standard,ohos:chipset"/>
   <project name="vendor_hihope" path="vendor/hihope" groups="default,ohos:mini,ohos:standard,ohos:chipset"/>
 </manifest>

--- a/chipsets/dayu200/dayu200.xml
+++ b/chipsets/dayu200/dayu200.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <remote name="gitee" fetch="https://gitee.com/openharmony/" />

--- a/chipsets/dayu210.xml
+++ b/chipsets/dayu210.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/dayu210/dayu210.xml
+++ b/chipsets/dayu210/dayu210.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_board_hihope" path="device/board/hihope" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:chipset"/>

--- a/chipsets/dev_wifi_a.xml
+++ b/chipsets/dev_wifi_a.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/dev_wifi_a/dev_wifi_a.xml
+++ b/chipsets/dev_wifi_a/dev_wifi_a.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_soc_asrmicro" path="device/soc/asrmicro" groups="default,ohos:mini"/>

--- a/chipsets/gr5515_sk.xml
+++ b/chipsets/gr5515_sk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/gr5515_sk/gr5515_sk.xml
+++ b/chipsets/gr5515_sk/gr5515_sk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_soc_goodix" path="device/soc/goodix" groups="default,ohos:mini,ohos:small"/>

--- a/chipsets/hispark/hispark.xml
+++ b/chipsets/hispark/hispark.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_soc_hisilicon" path="device/soc/hisilicon" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:chipset"/>

--- a/chipsets/hispark_aries.xml
+++ b/chipsets/hispark_aries.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/hispark_pegasus.xml
+++ b/chipsets/hispark_pegasus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/hispark_taurus.xml
+++ b/chipsets/hispark_taurus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/hpm6750evk2.xml
+++ b/chipsets/hpm6750evk2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/hpm6750evk2/hpm6750evk2.xml
+++ b/chipsets/hpm6750evk2/hpm6750evk2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_soc_hpmicro" path="device/soc/hpmicro" groups="default,ohos:mini"/>

--- a/chipsets/isoftstone_zhiyuan.xml
+++ b/chipsets/isoftstone_zhiyuan.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/isoftstone_zhiyuan/isoftstone_zhiyuan.xml
+++ b/chipsets/isoftstone_zhiyuan/isoftstone_zhiyuan.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_soc_allwinner" path="device/soc/allwinner" groups="default,ohos:standard,ohos:chipset"/>

--- a/chipsets/khdvk_3566b.xml
+++ b/chipsets/khdvk_3566b.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/khdvk_3566b/khdvk_3566b.xml
+++ b/chipsets/khdvk_3566b/khdvk_3566b.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_board_kaihong" path="device/board/kaihong" groups="default,ohos:standard,ohos:chipset"/>

--- a/chipsets/lingpi.xml
+++ b/chipsets/lingpi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/lockzhiner/lingpi.xml
+++ b/chipsets/lockzhiner/lingpi.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_board_lockzhiner" path="device/board/lockzhiner" groups="default,ohos:mini"/>

--- a/chipsets/milos_dk_n_8mini.xml
+++ b/chipsets/milos_dk_n_8mini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/milos_dk_n_8mini/milos_dk_n_8mini.xml
+++ b/chipsets/milos_dk_n_8mini/milos_dk_n_8mini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_board_osware" path="device/board/osware" groups="default,ohos:standard,ohos:chipset"/>

--- a/chipsets/neptune100.xml
+++ b/chipsets/neptune100.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/neptune100/neptune100.xml
+++ b/chipsets/neptune100/neptune100.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_soc_winnermicro" path="device/soc/winnermicro" groups="default,ohos:mini,ohos:chipset"/>

--- a/chipsets/niobe407.xml
+++ b/chipsets/niobe407.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/niobe407/niobe407.xml
+++ b/chipsets/niobe407/niobe407.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_board_talkweb" path="device/board/talkweb" groups="default,ohos:mini"/>

--- a/chipsets/niobeu4.xml
+++ b/chipsets/niobeu4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/niobeu4/niobeu4.xml
+++ b/chipsets/niobeu4/niobeu4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
   <project name="device_soc_esp" path="device/soc/esp" groups="default,ohos:mini,ohos:chipset"/>
   <project name="vendor_openvalley" path="vendor/openvalley" groups="default,ohos:mini,ohos:chipset"/>

--- a/chipsets/qemu.xml
+++ b/chipsets/qemu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/qemu/qemu.xml
+++ b/chipsets/qemu/qemu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_qemu" path="device/qemu" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:chipset"/>

--- a/chipsets/telink_b91.xml
+++ b/chipsets/telink_b91.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/telink_b91/telink_b91.xml
+++ b/chipsets/telink_b91/telink_b91.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_soc_telink" path="device/soc/telink" groups="default,ohos:mini"/>

--- a/chipsets/unionpi_tiger.xml
+++ b/chipsets/unionpi_tiger.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/unionpi_tiger/unionpi_tiger.xml
+++ b/chipsets/unionpi_tiger/unionpi_tiger.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_board_unionman" path="device/board/unionman" groups="default,ohos:standard,ohos:chipset"/>

--- a/chipsets/v200zr.xml
+++ b/chipsets/v200zr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/chipsets/v200zr/v200zr.xml
+++ b/chipsets/v200zr/v200zr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <project name="device_board_fnlink" path="device/board/fnlink" groups="default,ohos:mini,ohos:small"/>

--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <include name="ohos/ohos.xml" />

--- a/ohos/ohos.xml
+++ b/ohos/ohos.xml
@@ -3,6 +3,8 @@
   <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
+  <remote name="gitee" fetch="https://gitee.com/openharmony/" />
+
   <project name="inputmethod_imf" path="base/inputmethod/imf" groups="default,ohos:standard,ohos:system"/>
   <project name="ability_ability_lite" path="foundation/ability/ability_lite" groups="default,ohos:mini,ohos:small"/>
   <project name="arkui_ace_engine_lite" path="foundation/arkui/ace_engine_lite" groups="default,ohos:mini,ohos:small"/>
@@ -155,8 +157,8 @@
   <project name="communication_dhcp" path="foundation/communication/dhcp" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>
   <project name="developtools_bytrace" path="developtools/bytrace" groups="default,ohos:standard,ohos:system,ohos:chipset"/>
   <project name="developtools_hdc" path="developtools/hdc" groups="default,ohos:standard,ohos:system,ohos:chipset"/>
-  <project name="developtools_smartperf_host" path="developtools/smartperf_host" groups="default,ohos:standard,ohos:system"/>
-  <project name="developtools_profiler" path="developtools/profiler" groups="default,ohos:standard,ohos:system,ohos:chipset"/>
+  <project name="developtools_smartperf_host" remote="gitee" path="developtools/smartperf_host" groups="default,ohos:standard,ohos:system"/>
+  <project name="developtools_profiler" remote="gitee" path="developtools/profiler" groups="default,ohos:standard,ohos:system,ohos:chipset"/>
   <project name="developtools_hiperf" path="developtools/hiperf" groups="default,ohos:standard,ohos:system"/>
   <project name="developtools_global_resource_tool" path="developtools/global_resource_tool" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system"/>
   <project name="distributeddatamgr_relational_store" path="foundation/distributeddatamgr/relational_store" groups="default,ohos:standard,ohos:system"/>
@@ -169,13 +171,13 @@
   <project name="ability_dmsfwk" path="foundation/ability/dmsfwk" groups="default,ohos:standard,ohos:system"/>
   <project name="systemabilitymgr_safwk" path="foundation/systemabilitymgr/safwk" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>
   <project name="systemabilitymgr_samgr" path="foundation/systemabilitymgr/samgr" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>
-  <project name="docs" path="docs" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system"/>
+  <project name="docs" remote="gitee" path="docs" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system"/>
   <project name="filemanagement_dfs_service" path="foundation/filemanagement/dfs_service" groups="default,ohos:standard,ohos:system"/>
   <project name="filemanagement_file_api" path="foundation/filemanagement/file_api" groups="default,ohos:standard,ohos:system"/>
   <project name="filemanagement_storage_service" path="foundation/filemanagement/storage_service" groups="default,ohos:standard,ohos:system,ohos:chipset"/>
   <project name="filemanagement_user_file_service" path="foundation/filemanagement/user_file_service" groups="default,ohos:standard,ohos:system"/>
   <project name="filemanagement_app_file_service" path="foundation/filemanagement/app_file_service" groups="default,ohos:standard,ohos:system"/>
-  <project name="global_i18n" path="base/global/i18n" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system"/>
+  <project name="global_i18n" remote="gitee" path="base/global/i18n" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system"/>
   <project name="global_resource_management" path="base/global/resource_management" groups="default,ohos:standard,ohos:system"/>
   <project name="global_timezone" path="base/global/timezone" groups="default,ohos:standard,ohos:system"/>
   <project name="graphic_graphic_2d" path="foundation/graphic/graphic_2d" groups="default,ohos:standard,ohos:system,ohos:chipset"/>
@@ -207,7 +209,7 @@
   <project name="multimedia_camera_framework" path="foundation/multimedia/camera_framework" groups="default,ohos:standard,ohos:system"/>
   <project name="multimedia_histreamer" path="foundation/multimedia/histreamer" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system"/>
   <project name="multimedia_player_framework" path="foundation/multimedia/player_framework" groups="default,ohos:standard,ohos:system"/>
-  <project name="multimedia_av_codec" path="foundation/multimedia/av_codec" groups="default,ohos:standard,ohos:system"/>
+  <project name="multimedia_av_codec" remote="gitee" path="foundation/multimedia/av_codec" groups="default,ohos:standard,ohos:system"/>
   <project name="multimedia_media_library" path="foundation/multimedia/media_library" groups="default,ohos:standard,ohos:system"/>
   <project name="multimedia_image_framework" path="foundation/multimedia/image_framework" groups="default,ohos:standard,ohos:system"/>
   <project name="multimedia_av_session" path="foundation/multimedia/av_session" groups="default,ohos:standard,ohos:system"/>
@@ -283,12 +285,12 @@
   <project name="third_party_openh264" path="third_party/openh264" groups="default,ohos:standard,ohos:system"/>
   <project name="update_update_app" path="base/update/update_app" groups="default,ohos:standard,ohos:system"/>
   <project name="update_packaging_tools" path="base/update/packaging_tools" groups="default,ohos:standard,ohos:system"/>
-  <project name="update_updater" path="base/update/updater" groups="default,ohos:standard,ohos:system"/>
+  <project name="update_updater" remote="gitee" path="base/update/updater" groups="default,ohos:standard,ohos:system"/>
   <project name="update_update_service" path="base/update/updateservice" groups="default,ohos:standard,ohos:system"/>
   <project name="update_sys_installer" path="base/update/sys_installer" groups="default,ohos:standard,ohos:system"/>
   <project name="commonlibrary_c_utils" path="commonlibrary/c_utils" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>
   <project name="usb_usb_manager" path="base/usb/usb_manager" groups="default,ohos:standard,ohos:system"/>
-  <project name="xts_acts" path="test/xts/acts" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system"/>
+  <project name="xts_acts" remote="gitee" path="test/xts/acts" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system"/>
   <project name="xts_device_attest" path="test/xts/device_attest" groups="default,ohos:standard,ohos:system"/>
   <project name="xts_device_attest_lite" path="test/xts/device_attest_lite" groups="default,ohos:mini,ohos:small,ohos:system"/>
   <project name="distributedhardware_device_manager" path="foundation/distributedhardware/device_manager" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>
@@ -326,7 +328,7 @@
   <project name="commonlibrary_memory_utils" path="commonlibrary/memory_utils" groups="default,ohos:standard,ohos:system"/>
   <project name="msdp_device_status" path="base/msdp/device_status" groups="default,ohos:standard,ohos:system"/>
   <project name="developtools_syscap_codec" path="developtools/syscap_codec" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>
-  <project name="third_party_mindspore" path="third_party/mindspore" clone-depth="1" groups="default,ohos:standard,ohos:system">
+  <project name="third_party_mindspore" remote="gitee" path="third_party/mindspore" clone-depth="1" groups="default,ohos:standard,ohos:system">
       <linkfile dest="foundation/ai/mindspore" src="."/>
   </project>
   <project name="web_webview" path="base/web/webview" groups="default,ohos:standard,ohos:system"/>
@@ -345,7 +347,7 @@
   <project name="security_privacy_center" path="applications/standard/security_privacy_center" groups="default,ohos:standard,ohos:system"/>
   <project name="ai_neural_network_runtime" path="foundation/ai/neural_network_runtime" groups="default,ohos:standard,ohos:system"/>
   <project name="third_party_libbpf" path="third_party/libbpf" groups="default,ohos:standard,ohos:system,ohos:chipset"/>
-  <project name="third_party_vk-gl-cts" path="third_party/vk-gl-cts" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>
+  <project name="third_party_vk-gl-cts" remote="gitee" path="third_party/vk-gl-cts" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>
   <project name="third_party_spirv-tools" path="third_party/spirv-tools" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>
   <project name="third_party_glslang" path="third_party/glslang" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>
   <project name="third_party_spirv-headers" path="third_party/spirv-headers" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset"/>

--- a/ohos/ohos.xml
+++ b/ohos/ohos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="." name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
   <default remote="origin" revision="OpenHarmony-4.0-Release" sync-j="4" />
 
   <remote name="gitee" fetch="https://gitee.com/openharmony/" />

--- a/tag/monthly_20230913_1922_tag.xml
+++ b/tag/monthly_20230913_1922_tag.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote name="origin" fetch="." review="https://openharmony.gitee.com/openharmony/"/>
+  <remote name="origin" fetch="https://github.com/eclipse-oniro-mirrors" review="https://openharmony.gitee.com/openharmony/"/>
   
   <default remote="origin" revision="monthly_20230815" sync-j="4"/>
   


### PR DESCRIPTION
Preparation step to use the 4.0 release branch as default. Port patches form 3.2 release branch to use the mirror and gitee fallbacks.