### PR TITLE
github-ci: run CI pipeline on oniro-runner and CI optimizations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,29 +10,14 @@ on:
 
 env:
   CI_MANIFEST_NAME: default.xml
-  CI_RUNNER_PERSISTENT_STORAGE: /home/github-runner/persistent_storage
-  CI_DOCKER_PERSISTENT_STORAGE: /home/openharmony/persistent_storage
 
 jobs:
 
-  prepare-image:
-    # workaround to env variable non being available in pull_sources.containers.volumes
-    # this job simply forwards env variables to job's output. 
-    runs-on: oniro-runner
-    outputs:
-      runner_persistent_storage: ${{ env.CI_RUNNER_PERSISTENT_STORAGE }}
-      docker_persistent_storage: ${{ env.CI_DOCKER_PERSISTENT_STORAGE }}
-    steps:       
-      - run: true
-
   pull_sources:
     runs-on: oniro-runner
-    needs: [prepare-image]
 
     container:
       image: swr.cn-south-1.myhuaweicloud.com/openharmony-docker/docker_oh_standard:3.2
-      volumes:
-        - ${{ needs.prepare-image.outputs.runner_persistent_storage }}:${{ needs.prepare-image.outputs.docker_persistent_storage }}
 
     steps:
 
@@ -63,65 +48,40 @@ jobs:
 
       - name: Sync mirror
         run: |
-          # Create/maintain a mirror of all manifest repositories in runner
-          # persistent storage, and use that as reference when initializing the
-          # build repo, effectively reducing the time spent fetching git repos to
-          # almost nothing.
-          #
-          # If for some reason, the repo mirror becomes corrupted, a pipeline with
-          # $REBUILD_REPO_MIRROR set to a non-empty value will remove the entire
-          # mirror, and rebuild it from scratch.
-          #
-          # Note the use of fd 9 to hold a lock while accessing the $REPO_MIRROR
-          # path, so we can handle parallel jobs.  First we open the lock file on fd
-          # 9, then we lock it, and close/unlock it after repo sync.
-          if [ -n "$CI_DOCKER_PERSISTENT_STORAGE" ] ; then
-            REPO_MIRROR="$CI_DOCKER_PERSISTENT_STORAGE/repo-mirrors" ;
-            mkdir -p $(dirname $REPO_MIRROR) ;
-            exec 9>$REPO_MIRROR.lock ; flock 9 ;
-            if [ -n "$REBUILD_REPO_MIRROR" ] ; then
-              rm -rf "$REPO_MIRROR" ;
-            fi ;
-            if [ ! -e "$REPO_MIRROR" ] ; then
-              echo "Creating new repo mirror @ $REPO_MIRROR" ;
-              mkdir -p "$REPO_MIRROR" ;
-              pushd "$REPO_MIRROR" ;
-              repo init -u "$GITHUB_WORKSPACE" -m "$CI_MANIFEST_NAME" --mirror ;
-            else
-              echo "Reusing repo mirror @ $REPO_MIRROR" ;
-              pushd "$REPO_MIRROR" ;
-              repo init -u "$GITHUB_WORKSPACE" -m "$CI_MANIFEST_NAME";
-            fi ;
-            repo sync --no-repo-verify --force-sync;
-            repo forall -c 'git lfs pull'
+          REPO_MIRROR="/__w/repo-mirrors" ;
+          if [ ! -e "$REPO_MIRROR" ] ; then
+            echo "Creating new repo mirror @ $REPO_MIRROR" ;
+            mkdir -p "$REPO_MIRROR" ;
+            pushd "$REPO_MIRROR" ;
+            repo init -u "$GITHUB_WORKSPACE" -m "$CI_MANIFEST_NAME" --mirror ;
+            repo sync -c --no-repo-verify --force-sync -v;
             popd ;
-          fi
+          else
+            echo "Reusing repo mirror @ $REPO_MIRROR" ;
+          fi ;
+
 
       - name: Fetch sources
         run: |
           # Create the build environment in a repo subdir
           mkdir repo && cd repo
           repo init \
-            $(test -n "${CI_DOCKER_PERSISTENT_STORAGE:-}" && echo --reference "$CI_DOCKER_PERSISTENT_STORAGE"/repo-mirrors) \
+            --reference /__w/repo-mirrors \
             --manifest-url "$GITHUB_WORKSPACE" \
             --manifest-name "$CI_MANIFEST_NAME"
-          repo sync --no-repo-verify --force-sync
+          repo sync -c --no-repo-verify --force-sync -v
           repo forall -c 'git lfs pull'
-          # Release repo mirror lock if held
-          if [ -n "$REPO_MIRROR_ARG" ] ; then exec 9>&- ; fi
+
 
       - name: Download prebuilts
         run: |
-          mkdir -p $CI_DOCKER_PERSISTENT_STORAGE/openharmony_prebuilts
-          ln -sf $CI_DOCKER_PERSISTENT_STORAGE/openharmony_prebuilts openharmony_prebuilts
-          cd repo
-          ./build/prebuilts_download.sh
+          cd repo && ./build/prebuilts_download.sh
+
 
       - name: Build
         run: |
-          # a shared ccache on persistent storage is used to speed up the build 
-          cd repo
-          ./build.sh --ccache --share-ccache "$CI_DOCKER_PERSISTENT_STORAGE"/build-ccache --product-name rk3568
+          # a shared ccache is used to speed up the build 
+          cd repo && ./build.sh --ccache --product-name rk3568
 
       - name: Archive board image artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,30 @@ jobs:
 
     steps:
 
+      # cache gitee repositories that often fail to fetch because of network problems
+      - name: Cache restore gitee repositories
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /bin/repo
+            /__w/repo-mirrors/.repo
+            /__w/repo-mirrors/developtools_smartperf_host.git
+            /__w/repo-mirrors/developtools_profiler.git
+            /__w/repo-mirrors/docs.git
+            /__w/repo-mirrors/global_i18n.git
+            /__w/repo-mirrors/multimedia_av_codec.git
+            /__w/repo-mirrors/update_updater.git
+            /__w/repo-mirrors/xts_acts.git
+            /__w/repo-mirrors/third_party_mindspore.git
+            /__w/repo-mirrors/third_party_vk-gl-cts.git
+            /__w/repo-mirrors/device_board_hihope.git
+            /__w/repo-mirrors/device_soc_rockchip.git
+            
+          key:
+            cache-repos-${{ hashFiles('**/*.xml') }} 
+          restore-keys:
+            cache-repos-
+
       - name: Set up git-repo
         run: |
           if [ ! -f /bin/repo ]; then
@@ -60,6 +84,26 @@ jobs:
             echo "Reusing repo mirror @ $REPO_MIRROR" ;
           fi ;
 
+      - name: Cache save gitee repositories
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /bin/repo
+            /__w/repo-mirrors/.repo
+            /__w/repo-mirrors/developtools_smartperf_host.git
+            /__w/repo-mirrors/developtools_profiler.git
+            /__w/repo-mirrors/docs.git
+            /__w/repo-mirrors/global_i18n.git
+            /__w/repo-mirrors/multimedia_av_codec.git
+            /__w/repo-mirrors/update_updater.git
+            /__w/repo-mirrors/xts_acts.git
+            /__w/repo-mirrors/third_party_mindspore.git
+            /__w/repo-mirrors/third_party_vk-gl-cts.git
+            /__w/repo-mirrors/device_board_hihope.git
+            /__w/repo-mirrors/device_soc_rockchip.git
+            
+          key:
+            cache-repos-${{ hashFiles('**/*.xml') }} 
 
       - name: Fetch sources
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,11 +116,27 @@ jobs:
           repo sync -c --no-repo-verify --force-sync -v
           repo forall -c 'git lfs pull'
 
+      - name: Cache restore OpenHarmony prebuilts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+             /__w/manifest/manifest/openharmony_prebuilts
+          key:
+            cache-openharmony-prebuilts-${{ hashFiles('**/*.xml') }} 
+          restore-keys:
+            cache-openharmony-prebuilts-
 
       - name: Download prebuilts
         run: |
           cd repo && ./build/prebuilts_download.sh
 
+      - name: Cache save OpenHarmony prebuilts
+        uses: actions/cache/save@v4
+        with:
+          path: |
+             /__w/manifest/manifest/openharmony_prebuilts
+          key:
+            cache-openharmony-prebuilts-${{ hashFiles('**/*.xml') }} 
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,5 +86,5 @@ jobs:
       - name: Archive board image artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: rk3568_${{ github.ref_name }}
-          path: /__w/oniro4openharmony-manifest/oniro4openharmony-manifest/repo/out/rk3568/packages/phone/images/*
+          name: rk3568
+          path: /__w/manifest/manifest/repo/out/rk3568/packages/phone/images/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,7 @@ on:
       - '*'
 
 env:
-  CI_MANIFEST_URL: ${{ github.server_url }}/${{ github.repository }}
   CI_MANIFEST_NAME: default.xml
-  CI_MANIFEST_BRANCH: ${{ github.ref_name }}
   CI_RUNNER_PERSISTENT_STORAGE: /home/github-runner/persistent_storage
   CI_DOCKER_PERSISTENT_STORAGE: /home/openharmony/persistent_storage
 
@@ -45,6 +43,24 @@ jobs:
             chmod a+x /bin/repo
           fi
 
+      - uses: actions/checkout@v4
+
+      - name: Set up manifest workspace
+        run: |
+          # Tell git this repository is safe even if cloned with a different uid
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+
+          # The repo tool seems to insist on having a branch checked out or
+          # something like that... Without this we get errors like
+          #     fatal: couldn't find remote ref refs/heads/master
+          cd $GITHUB_WORKSPACE
+          git checkout -b master
+
+          # The repo command does not like shallow repos
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ] ; then
+            git fetch --unshallow ;
+          fi
+
       - name: Sync mirror
         run: |
           # Create/maintain a mirror of all manifest repositories in runner
@@ -70,11 +86,11 @@ jobs:
               echo "Creating new repo mirror @ $REPO_MIRROR" ;
               mkdir -p "$REPO_MIRROR" ;
               pushd "$REPO_MIRROR" ;
-              repo init -u "$CI_MANIFEST_URL" -m "$CI_MANIFEST_NAME" -b "$CI_MANIFEST_BRANCH" --mirror ;
+              repo init -u "$GITHUB_WORKSPACE" -m "$CI_MANIFEST_NAME" --mirror ;
             else
               echo "Reusing repo mirror @ $REPO_MIRROR" ;
               pushd "$REPO_MIRROR" ;
-              repo init -u "$CI_MANIFEST_URL" -m "$CI_MANIFEST_NAME" -b "$CI_MANIFEST_BRANCH";
+              repo init -u "$GITHUB_WORKSPACE" -m "$CI_MANIFEST_NAME";
             fi ;
             repo sync --no-repo-verify --force-sync;
             repo forall -c 'git lfs pull'
@@ -87,9 +103,8 @@ jobs:
           mkdir repo && cd repo
           repo init \
             $(test -n "${CI_DOCKER_PERSISTENT_STORAGE:-}" && echo --reference "$CI_DOCKER_PERSISTENT_STORAGE"/repo-mirrors) \
-            --manifest-url "$CI_MANIFEST_URL" \
-            --manifest-name "$CI_MANIFEST_NAME" \
-            --manifest-branch "$CI_MANIFEST_BRANCH"
+            --manifest-url "$GITHUB_WORKSPACE" \
+            --manifest-name "$CI_MANIFEST_NAME"
           repo sync --no-repo-verify --force-sync
           repo forall -c 'git lfs pull'
           # Release repo mirror lock if held

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,13 @@ jobs:
           key:
             cache-openharmony-prebuilts-${{ hashFiles('**/*.xml') }} 
 
+      - name: ccache
+        uses: actions/cache@v4
+        with:
+          path: /github/home/.ccache
+          key: build-ccache-${{ github.sha }}
+          restore-keys: build-ccache-
+
       - name: Build
         run: |
           # a shared ccache is used to speed up the build 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   prepare-image:
     # workaround to env variable non being available in pull_sources.containers.volumes
     # this job simply forwards env variables to job's output. 
-    runs-on: self-hosted
+    runs-on: oniro-runner
     outputs:
       runner_persistent_storage: ${{ env.CI_RUNNER_PERSISTENT_STORAGE }}
       docker_persistent_storage: ${{ env.CI_DOCKER_PERSISTENT_STORAGE }}
@@ -28,7 +28,7 @@ jobs:
       - run: true
 
   pull_sources:
-    runs-on: self-hosted
+    runs-on: oniro-runner
     needs: [prepare-image]
 
     container:


### PR DESCRIPTION
This pull request includes several updates to improve the CI pipeline's efficiency and reliability. Key changes include:

1. **Runner Setup and Modification**: A new runner labeled "oniro-runner" has been set up, with the build job now configured to utilize this runner. Adjustments were made to account for the lack of persistent storage on the runner, including the removal of parts that depend on persistent storage, thereby simplifying CI jobs.

2. **Artifact Naming Fix**: The artifact naming mechanism has been updated to address an issue where using `github.ref_name` in the artifact name led to errors in pull requests due to the presence of slashes.

3. **Workspace and Path Corrections**: Corrections have been made to the workspace path to ensure accurate directory usage.

4. **Cache Enhancements for Stability**: To counter network-related issues with fetching from gitee repositories, caching strategies have been implemented for the `.repo` directory, repo tool, gitee repositories and OpenHarmony prebuilts files. These files are essential for the build and are now cached to minimize network fetch failures. Specifically, OpenHarmony prebuilts are downloaded using the `./build/prebuilts_download.sh` script and are now properly cached.

5. **Build Acceleration through ccache**: The use of ccache has been introduced to speed up the build process. The ccache directory is now stored as cache to be restored in successive CI runs, enhancing build efficiency over time.

Overall, these updates aim to make the CI pipeline more efficient, reliable, and better suited to the project's needs by addressing specific challenges related to runner configuration, artifact naming, workspace management, network stability, and build acceleration.

Related issue: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3937
Related issue: https://gitlab.eclipse.org/eclipse/oniro-core/ohos-planning/-/issues/2