### PR TITLE
chipsets: add RPi4 board 6.1 support packages

### DIFF
--- a/chipsets/rpi.xml
+++ b/chipsets/rpi.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote fetch="https://gitee.com/openharmony" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://gitcode.com/openharmony" name="gitcode" review="https://gitcode.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="oniro" review="https://gitcode.com/openharmony/"/>
+  <default remote="oniro" revision="OpenHarmony-6.1-Release" sync-j="4"/>
+
+  <include name="ohos/ohos.xml" />
+  <include name="chipsets/rpi/rpi.xml" />
+</manifest>

--- a/chipsets/rpi/rpi.xml
+++ b/chipsets/rpi/rpi.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote fetch="https://gitee.com/openharmony" name="origin" review="https://openharmony.gitee.com/openharmony/"/>
+  <remote fetch="https://gitcode.com/openharmony" name="gitcode" review="https://gitcode.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro-mirrors" name="oniro" review="https://gitcode.com/openharmony/"/>
+  <remote fetch="https://github.com/eclipse-oniro4openharmony/" name="oniro4openharmony"/>
+  <default remote="oniro" revision="OpenHarmony-6.1-Release" sync-j="4"/>
+
+  <project name="device_board_rpi" path="device/board/rpi" groups="default,ohos:mini,ohos:small,ohos:standard,ohos:chipset" remote="oniro4openharmony" revision="OpenHarmony-6.1-Release"/>
+  <project name="device_soc_broadcom" path="device/soc/broadcom" groups="default,ohos:standard,ohos:chipset" remote="oniro4openharmony" revision="OpenHarmony-6.1-Release"/>
+  <project name="vendor_iscas" path="vendor/iscas" groups="default,ohos:mini,ohos:standard,ohos:chipset" remote="oniro4openharmony" revision="OpenHarmony-6.1-Release"/>
+</manifest>

--- a/ohos/ohos.xml
+++ b/ohos/ohos.xml
@@ -178,7 +178,7 @@
   <project groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system,ohos:chipset" name="communication_t2stack" path="foundation/communication/t2stack" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system,ohos:chipset" name="developtools_hdc" path="developtools/hdc" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="developtools_smartperf_host" path="developtools/smartperf_host" remote="oniro" revision="OpenHarmony-6.1-Release"/>
-  <project groups="default,ohos:standard,ohos:system,ohos:chipset" name="developtools_profiler" path="developtools/profiler" remote="oniro" revision="OpenHarmony-6.1-Release"/>
+  <project groups="default,ohos:standard,ohos:system,ohos:chipset" name="developtools_profiler" path="developtools/profiler" remote="gitcode" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="developtools_hiperf" path="developtools/hiperf" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system" name="developtools_global_resource_tool" path="developtools/global_resource_tool" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="distributeddatamgr_relational_store" path="foundation/distributeddatamgr/relational_store" remote="oniro" revision="OpenHarmony-6.1-Release"/>
@@ -229,7 +229,7 @@
   <project groups="default,ohos:standard,ohos:system" name="distributeddatamgr_pasteboard" path="foundation/distributeddatamgr/pasteboard" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="request_request" path="base/request/request" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="print_print_fwk" path="base/print/print_fwk" remote="oniro" revision="OpenHarmony-6.1-Release"/>
-  <project groups="default,ohos:standard,ohos:system" name="multimedia_audio_framework" path="foundation/multimedia/audio_framework" remote="oniro" revision="OpenHarmony-6.1-Release"/>
+  <project groups="default,ohos:standard,ohos:system" name="multimedia_audio_framework" path="foundation/multimedia/audio_framework" remote="gitcode" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="multimedia_camera_framework" path="foundation/multimedia/camera_framework" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:mini,ohos:small,ohos:standard,ohos:system" name="multimedia_media_foundation" path="foundation/multimedia/media_foundation" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="multimedia_player_framework" path="foundation/multimedia/player_framework" remote="oniro" revision="OpenHarmony-6.1-Release"/>

--- a/ohos/ohos.xml
+++ b/ohos/ohos.xml
@@ -481,6 +481,7 @@
   <project groups="default,ohos:standard,ohos:system" name="applications_user_certificate_manager" path="applications/standard/user_certificate_manager" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="distributedhardware_mechbody_controller" path="foundation/distributedhardware/mechbody_controller" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="game_game_controller_framework" path="domains/game/game_controller_framework" remote="oniro" revision="OpenHarmony-6.1-Release"/>
+  <project groups="default,ohos:standard,ohos:system,cangjie" name="docs_cangjie" path="docs_cangjie" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system,cangjie" name="arkcompiler_cangjie_ark_interop" path="arkcompiler/cangjie_ark_interop" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system,cangjie" name="filemanagement_filemanagement_cangjie_wrapper" path="foundation/filemanagement/filemanagement_cangjie_wrapper" remote="oniro" revision="OpenHarmony-6.1-Release" />
   <project groups="default,ohos:standard,ohos:system,cangjie" name="global_global_cangjie_wrapper" path="base/global/global_cangjie_wrapper" remote="oniro" revision="OpenHarmony-6.1-Release" />
@@ -515,4 +516,7 @@
   <project groups="default,ohos:standard,ohos:system" name="third_party_meshoptimizer" path="third_party/meshoptimizer" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="third_party_libtiff" path="third_party/libtiff" remote="oniro" revision="OpenHarmony-6.1-Release"/>
   <project groups="default,ohos:standard,ohos:system" name="systemabilitymgr_selectionfwk" path="foundation/systemabilitymgr/selectionfwk" remote="oniro" revision="OpenHarmony-6.1-Release"/>
+  <project groups="default,ohos:standard,ohos:system" name="third_party_libvpx" path="third_party/libvpx" remote="oniro" revision="OpenHarmony-6.1-Release"/>
+  <project groups="default,ohos:standard,ohos:system" name="third_party_dav1d" path="third_party/dav1d" remote="oniro" revision="OpenHarmony-6.1-Release"/>
+  <project groups="default,ohos:mini,ohos:standard,ohos:system,ohos:chipset" name="communication_fusion_connectivity" path="foundation/communication/fusion_connectivity" remote="oniro" revision="OpenHarmony-6.1-Release"/>
 </manifest>

--- a/oniro.xml
+++ b/oniro.xml
@@ -10,5 +10,6 @@
   <!-- chipsets --> 
   <include name="chipsets/dayu200/dayu200.xml" /> 
   <include name="chipsets/oniro/oniro.xml" /> 
+  <include name="chipsets/rpi/rpi.xml" />
    
 </manifest> 


### PR DESCRIPTION
add RPi4 board support packages that include device_board_rpi, device_soc_broadcom and vendor_iscas.


Change-Id: Id78e7ab63aae1acf2671795dbfdfe246fd6f8f83